### PR TITLE
Support escaping array literals as tuples

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,6 +81,10 @@ exports.ident = function(val){
 
 exports.literal = function(val){
   if (null == val) return 'NULL';
+  if (Array.isArray(val)) {
+    var vals = val.map(exports.literal)
+    return "(" + vals.join(", ") + ")"
+  }
   var backslash = ~val.indexOf('\\');
   var prefix = backslash ? 'E' : '';
   val = val.replace(/'/g, "''");

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "escape",
     "query"
   ],
+  "scripts": {
+    "test": "mocha --require should --reporter spec"
+  },
   "dependencies": {},
   "devDependencies": {
     "mocha": "*",

--- a/test/index.js
+++ b/test/index.js
@@ -80,6 +80,10 @@ describe('escape.literal(val)', function(){
     escape.literal(undefined).should.equal('NULL');
   })
 
+  it('should return a tuple for arrays', function(){
+    escape.literal(["foo", "bar", "baz' DROP TABLE foo;"]).should.equal("('foo', 'bar', 'baz'' DROP TABLE foo;')");
+  })
+
   it('should quote', function(){
     escape.literal('hello world').should.equal("'hello world'");
   })


### PR DESCRIPTION
And add an entry to `scripts` so `npm test` works out of the box.