### PR TITLE
escape identifiers with caps to preserve capitalization

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ exports.literal = function(val){
 
 function validIdent(id) {
   if (reserved[id]) return false;
-  return /^[a-z_][a-z0-9_$]*$/i.test(id);
+  return /^[a-z_][a-z0-9_$]*$/.test(id);
 }
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -52,6 +52,7 @@ describe('escape.string(val)', function(){
 describe('escape.ident(val)', function(){
   it('should quote when necessary', function(){
     escape.ident('foo').should.equal('foo');
+    escape.ident('Foo').should.equal('"Foo"');
     escape.ident('_foo').should.equal('_foo');
     escape.ident('_foo_bar$baz').should.equal('_foo_bar$baz');
     escape.ident('test.some.stuff').should.equal('"test.some.stuff"');


### PR DESCRIPTION
Looks like you may have thought about this and already decided against it, so feel free to close, but I've got some capitalized table names (I have my reasons!) that I'd prefer for postgres not to automatically lowercase. 

My feeling is, if anyone is passing in a mixed-case table name, then that's what they really want, even if it's typically a crazy thing to want to do.
