### PR TITLE
Quoting for capitalised identifiers

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,7 +139,7 @@ exports.literal = function(val){
 
 function validIdent(id) {
   if (reserved[id]) return false;
-  return /^[a-z_][a-z0-9_$]*$/i.test(id);
+  return /^[a-z_][a-z0-9_$]*$/.test(id);
 }
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -72,6 +72,7 @@ describe('escape.ident(val)', function(){
     escape.ident('_foo_bar$baz').should.equal('_foo_bar$baz');
     escape.ident('test.some.stuff').should.equal('"test.some.stuff"');
     escape.ident('test."some".stuff').should.equal('"test.""some"".stuff"');
+    escape.ident('someStuff').should.equal('"someStuff"');
   })
 
   it('should quote reserved words', function(){


### PR DESCRIPTION
Currently if you use an identifer with capitals in it but no special characters, e.g. `someStuff`, pg-escape will _not_ quote the identifier. However this will result in postgres automatically converting the identifier to lower case (e.g. `somestuff`), which can cause some issues with table lookup.

This PR simply removes the case insensitive flag from the validIdent function, and adds one line to the tests for this function that checks that it quotes identifiers with capitals.
