### PR TITLE
adding handling for numbers, booleans, and JSON objects, with tests for each

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,9 +118,14 @@ exports.ident = function(val){
 
 exports.literal = function(val){
   if (null == val) return 'NULL';
+  if (typeof val === 'number') return val.toString();
+  if (typeof val === 'boolean') return val ? 'TRUE' : 'FALSE';
   if (Array.isArray(val)) {
     var vals = val.map(exports.literal)
     return "(" + vals.join(", ") + ")"
+  }
+  if (typeof val === 'object') {
+    return exports.literal(JSON.stringify(val));
   }
   var backslash = ~val.indexOf('\\');
   var prefix = backslash ? 'E' : '';

--- a/test/index.js
+++ b/test/index.js
@@ -116,6 +116,7 @@ describe('escape.literal(val)', function(){
     escape.literal(5).should.equal("5");
     escape.literal(5.5).should.equal("5.5");
     escape.literal(-20).should.equal("-20");
+    escape.literal(1234512345123451234512345).should.equal("1.2345123451234512e+24");
   })
 
   it('should return a boolean for booleans', function(){

--- a/test/index.js
+++ b/test/index.js
@@ -111,5 +111,21 @@ describe('escape.literal(val)', function(){
   it('should escape backslashes', function(){
     escape.literal('\\whoop\\').should.equal("E'\\\\whoop\\\\'");
   })
+
+  it('should return a number for numbers', function(){
+    escape.literal(5).should.equal("5");
+    escape.literal(5.5).should.equal("5.5");
+    escape.literal(-20).should.equal("-20");
+  })
+
+  it('should return a boolean for booleans', function(){
+    escape.literal(true).should.equal("TRUE");
+    escape.literal(false).should.equal("FALSE");
+  })
+
+  it('should return a quoted object for objects', function(){
+    escape.literal({test:'testing 123'}).should.equal("'{\"test\":\"testing 123\"}'");
+    escape.literal({test:'testing \' \\ 123', z: 5}).should.equal("E'{\"test\":\"testing '' \\\\\\\\ 123\",\"z\":5}'");
+  })
 })
 


### PR DESCRIPTION
Currently, the `pg-escape` library throws a `TypeError: val.indexOf is not a function` error when a number, boolean, or object is passed as an argument to `escape.literal`.  It would be preferable to handle literal numbers, booleans, and objects and convert them to the appropriate Postgres syntax.  This PR implements simple functionality to do so, with tests to cover the primary cases and a few edge cases.